### PR TITLE
feat: Add filtering and scroll behavior to todo list

### DIFF
--- a/app/src/main/java/io/fairboi/mytodoapp/MainActivity.kt
+++ b/app/src/main/java/io/fairboi/mytodoapp/MainActivity.kt
@@ -5,13 +5,10 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.navigation.compose.rememberNavController
-import io.fairboi.domain.model.ThemeSettings
 import io.fairboi.mytodoapp.di.AppComponent
 import io.fairboi.mytodoapp.navigation.NavGraph
 import io.fairboi.mytodoapp.ui.theme.MyTodoAppTheme
@@ -36,7 +33,7 @@ internal fun TodoApp(
 
 
     Log.d("TodoApp", "settings: $settings")
-    MyTodoAppTheme(
+     MyTodoAppTheme(
        themeSettings = settings.theme
     ) {
 

--- a/feature/list/build.gradle.kts
+++ b/feature/list/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     api(project(":domain"))
     api(project(":core:data"))
 
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/feature/list/src/main/java/io/fairboi/list/TodoItemsListScreen.kt
+++ b/feature/list/src/main/java/io/fairboi/list/TodoItemsListScreen.kt
@@ -3,20 +3,18 @@ package io.fairboi.list
 import android.Manifest
 import androidx.annotation.RequiresPermission
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import io.fairboi.list.components.TodoItemsListView
+import io.fairboi.list.components.TodosAppBar
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @RequiresPermission(Manifest.permission.VIBRATE)
@@ -25,22 +23,18 @@ fun TodoItemsListScreen(
     viewModel: TodoItemsListViewModel,
     modifier: Modifier = Modifier, toSettingsScreen: () -> Unit
 ) {
+    val uiState by viewModel.uiState.collectAsState()
+    val scrollState = rememberLazyListState()
+
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Todo Items") },
-                actions = {
-                    IconButton(onClick = toSettingsScreen) {
-                        Icon(Icons.Filled.Settings, contentDescription = "Settings")
-                    }
-                }
+            TodosAppBar(
+                viewModel = viewModel,
+                toSettingsScreen = toSettingsScreen,
+                scrollState = scrollState,
             )
         }
     ) { innerPadding ->
-        val uiState by viewModel.uiState.collectAsState()
-
-
-        Text("Здесь будет список задач")
 
         when (uiState.listState) {
             is TodoItemsUiState.ListState.Error -> {
@@ -59,6 +53,7 @@ fun TodoItemsListScreen(
                     onItemChecked = { viewModel.onItemChecked(it) },
                     onItemCreated = { viewModel.onTextTodoAdded(it) },
                     onItemRemoved = { viewModel.onItemRemoved(it) },
+                    scrollState = scrollState,
                     modifier = modifier.padding(innerPadding)
                 )
             }

--- a/feature/list/src/main/java/io/fairboi/list/TodoItemsListViewModel.kt
+++ b/feature/list/src/main/java/io/fairboi/list/TodoItemsListViewModel.kt
@@ -1,37 +1,60 @@
 package io.fairboi.list
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.fairboi.domain.model.todo.TodoId
 import io.fairboi.domain.model.todo.TodoItem
-import jakarta.inject.Inject
 import io.fairboi.domain.repositories.TodoItemsRepository
+import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+private const val TAG = "TodoItemsListViewModel"
 
 class TodoItemsListViewModel @Inject constructor(
     private val todoRepository: TodoItemsRepository,
 ) : ViewModel() {
+    private val _filterState = MutableStateFlow(TodoItemsUiState.FilterState.ALL)
     private val _uiState = MutableStateFlow(TodoItemsUiState.Initial)
     internal val uiState: StateFlow<TodoItemsUiState> = _uiState.asStateFlow()
 
     private fun getTodoItems() {
         viewModelScope.launch {
-            todoRepository.getItemsFlow()
-                .map {
-                    TodoItemsUiState.ListState.Loaded(it)
-                }.catch {
+            todoRepository
+                .getItemsFlow()
+                .combine<List<TodoItem>, TodoItemsUiState.FilterState, TodoItemsUiState.ListState>(
+                    _filterState
+                ) { items, filterState ->
+
+                    TodoItemsUiState.ListState.Loaded(
+                        items = items.filter(filterState.filter),
+                        filterState = filterState,
+                        completedCount = items.count { it.done }
+                    )
+                }
+                .catch {
                     TodoItemsUiState.ListState.Error(it.message ?: "Unknown error")
-                }.collect { todoItemsState ->
+                }
+                .stateIn(
+                    viewModelScope,
+                    SharingStarted.Eagerly,
+                    TodoItemsUiState.ListState.Loading
+                )
+                .collect { todoItemsState ->
                     _uiState.update {
                         it.copy(
-                            listState = todoItemsState
-                        )
+                            listState = todoItemsState,
+                            filterState = _filterState.value,
+
+                            )
                     }
                 }
         }
@@ -41,13 +64,13 @@ class TodoItemsListViewModel @Inject constructor(
         getTodoItems()
     }
 
-    private  fun addTodoItem( todoItem: TodoItem) {
-        viewModelScope.launch{
+    private fun addTodoItem(todoItem: TodoItem) {
+        viewModelScope.launch {
             todoRepository.addItem(todoItem)
         }
     }
 
-    internal  fun onTextTodoAdded(text:String) {
+    internal fun onTextTodoAdded(text: String) {
         val todoItem = TodoItem.fromText(text)
         addTodoItem(todoItem)
     }
@@ -62,6 +85,15 @@ class TodoItemsListViewModel @Inject constructor(
     internal fun onItemRemoved(itemId: TodoId) {
         viewModelScope.launch {
             todoRepository.deleteItemById(itemId)
+        }
+    }
+
+    internal fun onFilterChanged(filterState: TodoItemsUiState.FilterState) {
+        Log.d(TAG, "Updating filter: $filterState")
+        viewModelScope.launch {
+            _filterState.update {
+                filterState
+            }
         }
     }
 

--- a/feature/list/src/main/java/io/fairboi/list/TodoItemsUiState.kt
+++ b/feature/list/src/main/java/io/fairboi/list/TodoItemsUiState.kt
@@ -3,22 +3,28 @@ package io.fairboi.list
 import io.fairboi.domain.model.todo.TodoItem
 
 internal data class TodoItemsUiState(
-    val listState: ListState
-){
-    sealed class ListState{
+    val listState: ListState,
+    val filterState: FilterState
+) {
+    sealed class ListState {
         data object Loading : ListState()
-        data class Loaded(val items: List<TodoItem>) : ListState()
+        data class Loaded(
+            val items: List<TodoItem>,
+            val filterState: FilterState = FilterState.ALL,
+            val completedCount: Int,
+        ) : ListState()
+
         data class Error(val message: String) : ListState()
     }
 
-    companion object{
-        val Initial = TodoItemsUiState(ListState.Loading)
+    companion object {
+        val Initial = TodoItemsUiState(ListState.Loading, FilterState.ALL)
     }
 
-//    enum class FilterState(val filter: (TodoItem) -> Boolean) {
-//        ALL({ true }),
-//        NOT_COMPLETED({ !it.done })
-//    }
+    enum class FilterState(val filter: (TodoItem) -> Boolean) {
+        ALL({ true }),
+        NOT_COMPLETED({ !it.done })
+    }
 }
 
 

--- a/feature/list/src/main/java/io/fairboi/list/components/TodoItemsListView.kt
+++ b/feature/list/src/main/java/io/fairboi/list/components/TodoItemsListView.kt
@@ -7,6 +7,8 @@ import androidx.annotation.RequiresPermission
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -35,10 +37,15 @@ fun TodoItemsListView(
     onItemChecked: (TodoItem) -> Unit,
     onItemCreated: (String) -> Unit,
     onItemRemoved: (itemId: TodoId) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    scrollState: LazyListState = rememberLazyListState(),
 
-) {
-    LazyColumn(modifier = modifier) {
+    ) {
+
+    LazyColumn(
+        modifier = modifier,
+        state = scrollState,
+    ) {
         items(items.size) {
             val item = items[it]
 
@@ -61,7 +68,7 @@ fun TodoItemCreator(onItemCreated: (String) -> Unit) {
     ListItem(headlineContent = {
         TextField(
             value = text,
-            onValueChange = { text = it   },
+            onValueChange = { text = it },
             label = { Text("Add new task") },
             placeholder = { Text("Task name") },
             singleLine = true,
@@ -84,6 +91,7 @@ fun TodoItemCreator(onItemCreated: (String) -> Unit) {
 
 
 @RequiresApi(Build.VERSION_CODES.O)
+@RequiresPermission(Manifest.permission.VIBRATE)
 @Preview
 @Composable
 private fun TodoItemsListViewPreview() {

--- a/feature/list/src/main/java/io/fairboi/list/components/TodosTopAppBar.kt
+++ b/feature/list/src/main/java/io/fairboi/list/components/TodosTopAppBar.kt
@@ -1,0 +1,124 @@
+package io.fairboi.list.components
+
+import android.util.Log
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.unit.max
+import androidx.compose.ui.unit.sp
+import io.fairboi.list.TodoItemsListViewModel
+import io.fairboi.list.TodoItemsUiState
+
+private const val TAG = "TodosAppBar"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodosAppBar(
+    viewModel: TodoItemsListViewModel,
+    modifier: Modifier = Modifier,
+    scrollState: LazyListState = rememberLazyListState(),
+    toSettingsScreen: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val filter = uiState.filterState
+    val theme = MaterialTheme
+    val scrollOffset = remember {
+        derivedStateOf {
+            val itemHeight = 150 // Assuming each item has a height of 150dp
+            val itemsBeforeFirstVisible = scrollState.firstVisibleItemIndex
+            (itemsBeforeFirstVisible * itemHeight) + scrollState.firstVisibleItemScrollOffset
+        }
+    }
+    val scrollOffsetPx = scrollOffset.value.toFloat()
+    val baseTopPadding = with(LocalDensity.current) { 30.dp.toPx() }
+    val baseStartPadding = with(LocalDensity.current) { 10.dp.toPx() }
+    val topPadding = calculatePadding(baseTopPadding, scrollOffsetPx, 0.dp, multiplier = 1f)
+    val startPadding = calculatePadding(baseStartPadding, scrollOffsetPx, 0.dp, multiplier = 0.5f)
+    val minRatio = 0f
+    val ratio = 1f - (scrollOffsetPx / 50f)
+    val effectiveRatio = if (ratio < minRatio) 0f else ratio
+    val textSize = lerp(24.sp, 36.sp, effectiveRatio)
+
+
+    TopAppBar(
+        modifier = modifier
+            .padding(
+                start = startPadding,
+                top = topPadding,
+            ),
+
+
+        title = {
+            Column {
+                Text(
+                    "Todo Items",
+                    fontSize = textSize,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (uiState.listState is TodoItemsUiState.ListState.Loaded && effectiveRatio > 0f)
+                    Text(
+                        "Done – ${(uiState.listState as TodoItemsUiState.ListState.Loaded).completedCount}",
+                        style = theme.typography.labelMedium,
+                        //opacity 1f -> 0f
+                        color = theme.colorScheme.onSurface.copy(alpha = effectiveRatio)
+                    )
+            }
+        },
+        actions = {
+            IconButton(onClick = {
+                val newFilter = when (filter) {
+                    TodoItemsUiState.FilterState.ALL -> TodoItemsUiState.FilterState.NOT_COMPLETED
+                    TodoItemsUiState.FilterState.NOT_COMPLETED -> TodoItemsUiState.FilterState.ALL
+                }
+                Log.d(TAG, "Filter toggled (${filter.name} -> ${newFilter.name})")
+                viewModel.onFilterChanged(
+                    newFilter
+                )
+            }) {
+                Icon(
+                    if (filter == TodoItemsUiState.FilterState.ALL) Icons.Outlined.Visibility else Icons.Outlined.VisibilityOff,
+                    contentDescription = "Toggle visibility"
+                )
+            }
+
+
+            IconButton(onClick = toSettingsScreen) {
+                Icon(Icons.Filled.Settings, contentDescription = "Settings")
+            }
+        }
+    )
+}
+
+private fun calculatePadding(
+    basePadding: Float,
+    scrollOffset: Float,
+    minPadding: Dp = 0.dp,
+    multiplier: Float = 1f,
+): Dp {
+
+    val calculatedPadding = (basePadding - scrollOffset * multiplier).dp
+    return max(calculatedPadding, minPadding)
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-p
 kotlin-ksp-gradle = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }


### PR DESCRIPTION
This commit introduces filtering and scroll behavior to the todo list screen:

- Adds a filter button to the top app bar to toggle between showing all items and only incomplete items.
- The top app bar now shrinks and hides the completed count text as the user scrolls down the list.
- Adds a filter state to the `TodoItemsUiState` and updates the view model to apply the filter when fetching items.
- The list view now uses a `LazyListState` to track the scroll position.
- The completed count text in the top app bar is now only shown when the list is scrolled to the top.